### PR TITLE
Added: 增加IPv6支持

### DIFF
--- a/client/fdht_delete.c
+++ b/client/fdht_delete.c
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
 	{
 		keys_arg = argv[3];
 		snprintf(object_buff, sizeof(object_buff), "%s", argv[2]);
-		if (splitEx(object_buff, ':', parts2, 2) != 2)
+		if (parseAddress(object_buff, parts2) !=2 )
 		{
 			usage(argv[0]);
 			return EINVAL;

--- a/client/fdht_get.c
+++ b/client/fdht_get.c
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
 	{
 		keys_arg = argv[3];
 		snprintf(object_buff, sizeof(object_buff), "%s", argv[2]);
-		if (splitEx(object_buff, ':', parts2, 2) != 2)
+		if (parseAddress(object_buff, parts2) !=2 )
 		{
 			usage(argv[0]);
 			return EINVAL;

--- a/common/fdht_func.c
+++ b/common/fdht_func.c
@@ -22,6 +22,7 @@
 #include <time.h>
 #include "logger.h"
 #include "sockopt.h"
+#include "local_ip_func.h"
 #include "shared_func.h"
 #include "ini_file_reader.h"
 #include "fdht_func.h"
@@ -444,7 +445,7 @@ int fdht_load_groups_ex(IniContext *pIniContext, \
 		pItemEnd = pItemInfo + pServerArray->count;
 		for (; pItemInfo<pItemEnd; pItemInfo++)
 		{
-			if (splitEx(pItemInfo->value, ':', ip_port, 2) != 2)
+			if (parseAddress(pItemInfo->value, ip_port) !=2 )
 			{
 				logError("file: "__FILE__", line: %d, " \
 					"\"%s\" 's value \"%s\" is invalid, "\
@@ -464,12 +465,13 @@ int fdht_load_groups_ex(IniContext *pIniContext, \
 				return EINVAL;
 			}
 
-			if (strcmp(pServerInfo->ip_addr, "127.0.0.1") == 0)
+			if (strcmp(pServerInfo->ip_addr, LOCAL_LOOPBACK_IPv4) == 0 ||
+				strcmp(pServerInfo->ip_addr, LOCAL_LOOPBACK_IPv6) ==0 )
 			{
 				logError("file: "__FILE__", line: %d, " \
 					"group%d: invalid hostname \"%s\", " \
-					"ip address can not be 127.0.0.1!", \
-					__LINE__, group_id, pItemInfo->value);
+					"ip address can not be %s!", \
+					__LINE__, group_id, pItemInfo->value, pServerInfo->ip_addr);
 				return EINVAL;
 			}
 

--- a/common/fdht_proto.c
+++ b/common/fdht_proto.c
@@ -172,7 +172,15 @@ int fdht_connect_server_nb(FDHTServerInfo *pServer, const int connect_timeout)
 	{
 		close(pServer->sock);
 	}
-	pServer->sock = socket(AF_INET, SOCK_STREAM, 0);
+	
+	// 通过判断IP地址是IPv4或者IPv6，根据结果进行初始化
+    if (is_ipv6_addr(pServer->ip_addr))     
+    {
+        pServer->sock = socket(AF_INET6, SOCK_STREAM, 0);
+    }else{
+        pServer->sock = socket(AF_INET, SOCK_STREAM, 0);
+    }
+	
 	if(pServer->sock < 0)
 	{
 		logError("file: "__FILE__", line: %d, " \
@@ -213,7 +221,15 @@ int fdht_connect_server(FDHTServerInfo *pServer)
 	{
 		close(pServer->sock);
 	}
-	pServer->sock = socket(AF_INET, SOCK_STREAM, 0);
+	
+    // 通过判断IP地址是IPv4或者IPv6，根据结果进行初始化
+    if (is_ipv6_addr(pServer->ip_addr))     
+    {
+        pServer->sock = socket(AF_INET6, SOCK_STREAM, 0);
+    }else{
+        pServer->sock = socket(AF_INET, SOCK_STREAM, 0);
+    }
+
 	if(pServer->sock < 0)
 	{
 		logError("file: "__FILE__", line: %d, " \

--- a/conf/fdht_servers.conf
+++ b/conf/fdht_servers.conf
@@ -1,3 +1,8 @@
+# IPv4:
+# for example: 192.168.0.196:11411
+#
+# IPv6:
+# or example: [fd15:4ba5:5a2b:1008:c258:17db:b2af:a5ba]:11411
 
 group_count = 1
 group0 = 192.168.0.196:11411

--- a/conf/fdhtd.conf
+++ b/conf/fdhtd.conf
@@ -1,5 +1,18 @@
+# is this config file disabled
+# false for enabled
+# true for disabled
 disabled=false
+
+# bind an address of this host
+# empty for bind all addresses of this host
+# IPv4:
+# for example: 192.168.2.100
+#
+# IPv6:
+# or example: [2409:8a20:42d:2f40:587a:4c47:72c0:ad8e]
 bind_addr=
+
+# the fdht server port
 port=11411
 
 # connect timeout in seconds

--- a/server/db_recovery.c
+++ b/server/db_recovery.c
@@ -313,7 +313,8 @@ static int fdht_recover_data(const int start_binlog_index, \
 		IP_ADDRESS_SIZE * g_local_host_ip_count;
         for (p=g_local_host_ip_addrs; p<pEnd; p+=IP_ADDRESS_SIZE)
 	{
-		if (strcmp(p, "127.0.0.1") != 0)
+		if (strcmp(p, "127.0.0.1") != 0 &&
+		     strcmp(p, "::1") != 0)
 		{
 			strcpy(reader.ip_addr, p);
 			break;

--- a/server/fdht_io.c
+++ b/server/fdht_io.c
@@ -60,7 +60,7 @@ void recv_notify_read(int sock, short event, void *arg)
 	struct nio_thread_data *pThreadData;
 	struct fast_task_info *pTask;
 	char szClientIp[IP_ADDRESS_SIZE];
-	in_addr_t client_addr;
+	in_addr_64_t client_addr;
 
 	while (1)
 	{
@@ -87,11 +87,11 @@ void recv_notify_read(int sock, short event, void *arg)
 		}
 
 		client_addr = getPeerIpaddr(incomesock, \
-				szClientIp, IP_ADDRESS_SIZE);
+				szClientIp, IP_ADDRESS_SIZE); 
 		if (g_allow_ip_count >= 0)
 		{
 			if (bsearch(&client_addr, g_allow_ip_addrs, \
-					g_allow_ip_count, sizeof(in_addr_t), \
+					g_allow_ip_count, sizeof(in_addr_64_t), \
 					cmp_by_ip_addr_t) == NULL)
 			{
 				logError("file: "__FILE__", line: %d, " \

--- a/server/fdhtd.c
+++ b/server/fdhtd.c
@@ -117,7 +117,22 @@ int main(int argc, char *argv[])
 		return errno;
 	}
 
-	sock = socketServer(bind_addr, g_server_port, &result);
+    // 如果bind_addr未设置
+    if(strlen(bind_addr) == 0){
+
+        // 如果当前服务不存在IPv4地址，但是存在IPv6地址，则自动绑定IPv6地址
+        if(!checkHostHasIPv4Addr() && checkHostHasIPv6Addr()){
+            sock = socketServerIPv6(bind_addr, g_server_port, &result);
+        }else{
+            sock = socketServer(bind_addr, g_server_port, &result);
+        }
+    }else if (is_ipv6_addr(bind_addr))     // 通过判断IP地址是IPv4或者IPv6，根据结果进行初始化
+    {
+        sock = socketServerIPv6(bind_addr, g_server_port, &result);
+    }else{
+        sock = socketServer(bind_addr, g_server_port, &result);
+    }
+
 	if (sock < 0)
 	{
 		fdht_func_destroy();

--- a/server/func.c
+++ b/server/func.c
@@ -7,6 +7,7 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <ifaddrs.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1290,3 +1291,55 @@ int fdht_stat_file_sync_func(void *args)
 	return fdht_write_to_stat_file();
 }
 
+
+// 判断当前服务器是否存在IPv4地址
+bool checkHostHasIPv4Addr(){
+    struct ifaddrs *ifaddr, *ifa;
+    if (getifaddrs(&ifaddr) == -1) {
+        return false;
+    }
+
+    bool hasIPv4 = false;
+    for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
+        if (ifa->ifa_addr == NULL) {
+            continue;
+        }
+        if (strcmp(ifa->ifa_name, "lo") == 0) { // 排除lo接口
+            continue;
+        }
+        if (ifa->ifa_addr->sa_family == AF_INET) {
+            hasIPv4 = true;
+            break;
+        }
+    }
+
+    freeifaddrs(ifaddr);
+
+    return hasIPv4;
+}
+
+// 判断当前服务器是否存在IPv6地址
+bool checkHostHasIPv6Addr(){
+    struct ifaddrs *ifaddr, *ifa;
+    if (getifaddrs(&ifaddr) == -1) {
+        return false;
+    }
+
+    bool hasIPv6 = false;
+    for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
+        if (ifa->ifa_addr == NULL) {
+            continue;
+        }
+        if (strcmp(ifa->ifa_name, "lo") == 0) { // 排除lo接口
+            continue;
+        }
+        if (ifa->ifa_addr->sa_family == AF_INET6) {
+             hasIPv6 = true;
+            break;
+        }
+    }
+
+    freeifaddrs(ifaddr);
+
+    return hasIPv6;
+}

--- a/server/func.h
+++ b/server/func.h
@@ -42,6 +42,12 @@ int start_dl_detect_thread();
 
 int fdht_stat_file_sync_func(void *args);
 
+// 判断当前服务器是否存在IPv4地址
+bool checkHostHasIPv4Addr();
+
+// 判断当前服务器是否存在IPv6地址
+bool checkHostHasIPv6Addr();
+
 #ifdef __cplusplus
 }
 #endif

--- a/server/global.c
+++ b/server/global.c
@@ -56,7 +56,7 @@ int g_sync_until_timestamp = 0;
 int g_sync_done_timestamp = 0;
 
 int g_allow_ip_count = 0;  /* -1 means match any ip address */
-in_addr_t *g_allow_ip_addrs = NULL;  /* sorted array, asc order */
+in_addr_64_t *g_allow_ip_addrs = NULL;  /* sorted array, asc order */
 
 time_t g_server_start_time = 0;
 int g_store_type = FDHT_STORE_TYPE_BDB;

--- a/server/global.h
+++ b/server/global.h
@@ -72,7 +72,7 @@ extern int g_sync_until_timestamp;
 extern int g_sync_done_timestamp;
 
 extern int g_allow_ip_count;  /* -1 means match any ip address */
-extern in_addr_t *g_allow_ip_addrs;  /* sorted array, asc order */
+extern in_addr_64_t *g_allow_ip_addrs;  /* sorted array, asc order */
 
 extern time_t g_server_start_time;
 extern int g_store_type;

--- a/server/sync.c
+++ b/server/sync.c
@@ -1667,8 +1667,13 @@ static void* fdht_sync_thread_entrance(void* arg)
 		conn_result = 0;
 		while (g_continue_flag)
 		{
-			fdht_server.sock = \
-				socket(AF_INET, SOCK_STREAM, 0);
+			if(strchr(fdht_server.ip_addr, ':') != NULL){
+				fdht_server.sock = \
+					socket(AF_INET6, SOCK_STREAM, 0);
+			}else{
+				fdht_server.sock = \
+					socket(AF_INET, SOCK_STREAM, 0);
+			}
 			if(fdht_server.sock < 0)
 			{
 				logError("file: "__FILE__", line: %d, " \


### PR DESCRIPTION
1、增加配置文件解析IPv6地址的能力。
2、修改配置文件增加IPv6配置说明。
3、增加检测主机是否配置IPv4地址和是否配置IPv6地址的方法。
4、修改fdhtd.c文件中main方法，以支持IPv4和IPv6地址，当服务器为双栈时，优先选择IPv4地址。